### PR TITLE
Fix category mapping errors

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,18 +1,12 @@
 import { Link } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import { fetchCategories } from '../utils/api'
 function Navbar() {
   const [categories, setCategories] = useState([])
 
   useEffect(() => {
-    fetch('https://dummyjson.com/products/categories')
-      .then(res => res.json())
-      .then(data => {
-        const mapped = data.map(slug => ({
-          slug,
-          name: slug.replace(/-/g, ' ')
-        }))
-        setCategories(mapped)
-      })
+    fetchCategories()
+      .then(setCategories)
       .catch(err => {
         console.error(err)
         setCategories([])

--- a/src/pages/Categorias.jsx
+++ b/src/pages/Categorias.jsx
@@ -1,19 +1,13 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { fetchCategories } from '../utils/api'
 
 function Categorias() {
   const [categorias, setCategorias] = useState([])
 
   useEffect(() => {
-    fetch('https://dummyjson.com/products/categories')
-      .then(res => res.json())
-      .then(data => {
-        const mapped = data.map(slug => ({
-          slug,
-          name: slug.replace(/-/g, ' ')
-        }))
-        setCategorias(mapped)
-      })
+    fetchCategories()
+      .then(setCategorias)
       .catch(() => setCategorias([]))
   }, [])
 

--- a/src/pages/Productos.jsx
+++ b/src/pages/Productos.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import CardProducto from '../components/CardProducto'
 import CardCategoria from '../components/CardCategoria'
+import { fetchCategories } from '../utils/api'
 
 function Productos() {
   const { categoria } = useParams()
@@ -15,15 +16,8 @@ function Productos() {
         .then(data => setProductos(data.products || []))
         .catch(() => setProductos([]))
     } else {
-      fetch('https://dummyjson.com/products/categories')
-        .then(res => res.json())
-        .then(data => {
-          const mapped = data.map(slug => ({
-            slug,
-            name: slug.replace(/-/g, ' ')
-          }))
-          setCategorias(mapped)
-        })
+      fetchCategories()
+        .then(setCategorias)
         .catch(() => setCategorias([]))
     }
   }, [categoria])

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,15 @@
+export async function fetchCategories() {
+  try {
+    const res = await fetch('https://dummyjson.com/products/categories')
+    const data = await res.json()
+    if (Array.isArray(data)) {
+      return data.map(slug => ({
+        slug,
+        name: typeof slug === 'string' ? slug.replace(/-/g, ' ') : ''
+      }))
+    }
+    return []
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- guard against invalid responses when fetching categories
- centralize category fetch logic for reuse

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863f55217ac83319b0f9d8837cceb64