### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </StrictMode>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: ''
+  base: '/TP-7---Catalogo-de-Productos/'
 })


### PR DESCRIPTION
## Summary
- set Vite `base` to the repository folder
- configure `BrowserRouter` with the build `BASE_URL`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fa1ec2cd88331909996792881c474